### PR TITLE
Fix typos and stabilize failure count tests

### DIFF
--- a/src/circuitBreaker.ts
+++ b/src/circuitBreaker.ts
@@ -111,7 +111,10 @@ export class CircuitBreaker {
 
         const { id, abortController } = this.#abortManager.create();
         try {
-            const result = await Promise.race([promiseFunction(abortController.signal), this.#timeoutRejection(abortController.signal)]);
+            const tasks: Promise<any>[] = [promiseFunction(abortController.signal)];
+            const timeout = this.#timeoutRejection(abortController.signal);
+            if (timeout) tasks.push(timeout);
+            const result = await Promise.race(tasks);
             this.#abortManager.abort(id);
             this.#handleExecutionSuccess(result);
             return result as T;

--- a/src/window.ts
+++ b/src/window.ts
@@ -62,7 +62,13 @@ export class Window {
 
     #filterWithinWindow(timestamps: number[]): number[] {
         const cutoffTime = Date.now() - this.windowSizeMs;
-        const validIndex = timestamps.findIndex(timestamp => timestamp >= cutoffTime);
-        return validIndex !== -1 ? timestamps.slice(validIndex) : [];
+        let idx = 0;
+        while (idx < timestamps.length && timestamps[idx] < cutoffTime) {
+            idx++;
+        }
+        if (idx > 0) {
+            timestamps.splice(0, idx);
+        }
+        return timestamps;
     }
 }


### PR DESCRIPTION
## Summary
- fix some typos in test descriptions
- adjust failureThresholdCount tests so percentage threshold does not trigger
- reduce concurrency in tests to avoid timeouts
- avoid undefined promise in timeout race condition
- optimize timestamp window filtering
- clarify default timeout test result

